### PR TITLE
refactor(kosa): rename "validation" property to "meta"

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,15 +14,23 @@ It is designed to be and stay simple !!!
 {
   statusCode: 400,
   message: 'USER_REGISTER_BAD_REQUEST', // Comes from scope & status
-  validations: [ // Optional
-    {
-      field: 'email',
-      message: 'missing tld'
-    }, {
-      field: 'firstname',
-      message: 'should start with a capital'
-    }
-  ];
+  meta: { // Optional - contextual information
+    error: '...',
+    context: '...',
+    details: {
+      ...
+    },
+    validations: [
+      {
+        field: 'email',
+        message: 'missing tld'
+      }, {
+        field: 'firstname',
+        message: 'should start with a capital'
+      }
+    ]
+    ...
+  }
 }
 ```
 
@@ -32,7 +40,7 @@ Here are the constructor arguments:
 
 1. `scope` required string
 2. `statusCode` optional number
-3. `validations` optional array with validations errors from validators
+3. `meta` optional object with contextual information you might want to provide about the error
 
 Here is how you use it in your code.
 

--- a/src/index.js
+++ b/src/index.js
@@ -15,7 +15,7 @@ const validCodes = Object.keys(statusCodeMap).map(Number);
 const util = require('util');
 
 class Kosa {
-  constructor (scope, statusCode, validations) {
+  constructor (scope, statusCode, meta) {
 
     if (statusCode) {
       this.statusCode = Number(statusCode);
@@ -36,7 +36,7 @@ class Kosa {
       this.message = status;
     }
 
-    this.validations = validations || null;
+    this.meta = meta || null;
   }
 }
 // Can't use extends, since then it must use super() in constructor,

--- a/src/index.js
+++ b/src/index.js
@@ -36,7 +36,7 @@ class Kosa {
       this.message = status;
     }
 
-    this.meta = meta || null;
+    this.meta = meta || {};
   }
 }
 // Can't use extends, since then it must use super() in constructor,


### PR DESCRIPTION
As discussed previously, validation property naming isn't relevant anymore regarding the way this property is used.

